### PR TITLE
hackish way to get all devices

### DIFF
--- a/noson/src/sonossystem.h
+++ b/noson/src/sonossystem.h
@@ -196,7 +196,7 @@ namespace NSROOT
     SMServiceList m_smservices;
 
     static bool DeviceMatches(const char * serverString);
-    static bool FindDeviceDescription(std::string& url);
+    static bool FindDeviceDescriptions(std::vector<std::string>& urls);
     void RevokePlayers();
 
     static void CB_ZGTopology(void* handle);


### PR DESCRIPTION
not sure if you want this in addition to the existing fix, but I had the branch laying around. had the same issue I guess you solved, but solved it in a slightly different way (trying to get all devices, and then check the services it exposes).

commit message:
sometimes the first device to respond is e. g. a sub, which is not what
we want.

it solves kind of the same problem as
4d30308e03628031832041b7f2d758c17d316d9f, but more robust for future
device models.