### PR TITLE
add missing header files, to fix compilation errors when using GCC 13

### DIFF
--- a/noson/src/audioformat.h
+++ b/noson/src/audioformat.h
@@ -21,6 +21,7 @@
 
 #include "local_config.h"
 
+#include <cstdint>
 #include <string>
 
 namespace NSROOT

--- a/noson/src/filepicreader.h
+++ b/noson/src/filepicreader.h
@@ -25,6 +25,7 @@
 
 #include "streamreader.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Additional header file includes are required to compile Noson with GCC 13.

From https://gcc.gnu.org/gcc-13/porting_to.html:

> Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile. 