### PR TITLE
feature: expose Muse household ID via ZoneGroupTopology/System

### DIFF
--- a/noson/src/sonossystem.cpp
+++ b/noson/src/sonossystem.cpp
@@ -191,6 +191,18 @@ void System::RenewSubscriptions()
   m_subscriptionPool->RenewSubscriptions();
 }
 
+std::string System::GetMuseHouseholdID()
+{
+  OS::LockGuard lock(*m_mutex);
+  if (m_groupTopology)
+  {
+    ElementList attrs;
+    if (m_groupTopology->GetZoneGroupAttributes(attrs))
+      return attrs.GetValue("CurrentMuseHouseholdId");
+  }
+  return std::string();
+}
+
 ZoneList System::GetZoneList() const
 {
   OS::LockGuard lock(*m_mutex);

--- a/noson/src/sonossystem.h
+++ b/noson/src/sonossystem.h
@@ -83,8 +83,7 @@ namespace NSROOT
     // Device properties
     const std::string& GetHouseholdID() const { return m_householdID; }
 
-    // The "Muse" household id (e.g. "Sonos_xxx.yyy") used by the Sonos cloud
-    // content API; fetched live from ZoneGroupTopology. Empty if unavailable.
+    // Muse household id (form "Sonos_xxx.yyy") used by the cloud content API
     std::string GetMuseHouseholdID();
 
     const std::string& GetSerialNumber() const { return m_serialNumber; }

--- a/noson/src/sonossystem.h
+++ b/noson/src/sonossystem.h
@@ -83,6 +83,10 @@ namespace NSROOT
     // Device properties
     const std::string& GetHouseholdID() const { return m_householdID; }
 
+    // The "Muse" household id (e.g. "Sonos_xxx.yyy") used by the Sonos cloud
+    // content API; fetched live from ZoneGroupTopology. Empty if unavailable.
+    std::string GetMuseHouseholdID();
+
     const std::string& GetSerialNumber() const { return m_serialNumber; }
 
     const std::string& GetSoftwareVersion() const { return m_softwareVersion; }

--- a/noson/src/zonegrouptopology.cpp
+++ b/noson/src/zonegrouptopology.cpp
@@ -98,6 +98,13 @@ bool ZoneGroupTopology::GetZoneGroupState()
   return false;
 }
 
+bool ZoneGroupTopology::GetZoneGroupAttributes(ElementList& attributes)
+{
+  ElementList args;
+  attributes = Request("GetZoneGroupAttributes", args);
+  return (!attributes.empty() && attributes[0]->compare("GetZoneGroupAttributesResponse") == 0);
+}
+
 void ZoneGroupTopology::HandleEventMessage(EventMessagePtr msg)
 {
   if (!msg)

--- a/noson/src/zonegrouptopology.h
+++ b/noson/src/zonegrouptopology.h
@@ -53,6 +53,8 @@ namespace NSROOT
 
     bool GetZoneGroupState();
 
+    bool GetZoneGroupAttributes(ElementList& attributes);
+
     unsigned GetTopologyKey() const { return m_topologyKey; }
 
     Locked<ZoneList>& GetZoneList() { return m_zones; }


### PR DESCRIPTION
feature: expose Muse household ID via ZoneGroupTopology/System

adds ZoneGroupToplogy::GetZoneGroupAttributes() and System::GetMuseHouseholdID() which return the "Muse" household ID. this is needed in order to communicate with the Sonos cloud content API. this value cannot be retrieved from the cloud itself, so consumers need it from the local toplogy.

required PR before the YouTube Music PR in `noson-app` can be merged